### PR TITLE
Reduce build image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update --fix-missing && apt-get upgrade -y
 # install required packages from Kali repos
 COPY packages.sh /
 RUN ["sh", "packages.sh"]
+# Cleanup
+RUN apt-get clean
+RUN apt-get autoremove
 
 # dowload optional packages archives
 COPY optional_tools.sh /usr/bin/

--- a/packages.sh
+++ b/packages.sh
@@ -15,4 +15,4 @@ apt-get install -y  sudo \
                     libffi-dev \
                     python-dev \
                     postgresql \
-                    postgresql-client
+                    postgresql-client-9.1


### PR DESCRIPTION
- Cleanup apt archives after installing the core packages
- postgresql-client-9.1 is a dependency installed by optional tools so
- replace postgresql-client with this package
