### PR TITLE
Force "yes" for apt autoremove

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ["sh", "packages.sh"]
 
 # Cleanup
 RUN apt-get clean
-RUN apt-get autoremove
+RUN apt-get -y autoremove
 
 # dowload optional packages archives
 COPY optional_tools.sh /usr/bin/


### PR DESCRIPTION
This will ensure that "yes" is triggered for each prompted question and avoid lockings at autoremove execution.

Fix #32