### PR TITLE
Couple dependency issues resolved (Wapiti & Arachni)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM kalilinux/kali-linux-docker
 
-MAINTAINER @viyatb viyat.bhalodia@owasp.org, @alexandrasandulescu alecsandra.sandulescu@gmail.com
-
-# Kali signatures preventive update
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y gnupg
-RUN wget -q -O - archive.kali.org/archive-key.asc | apt-key add
+MAINTAINER r3naissance
 
 # install required packages from Kali repos
 COPY packages.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ["sh", "packages.sh"]
 RUN apt-get clean
 RUN apt-get -y autoremove
 
-RUN apt-get install kali-linux-full
+RUN apt-get install kali-linux-top10 kali-linux-web
 
 #Kali SSL lib-fix
 ENV PYCURL_SSL_LIBRARY openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM kalilinux/kali-linux-docker
 
 MAINTAINER r3naissance
 
+RUN apt-get update && apt-get dist-upgrade -y
+
 # install required packages from Kali repos
 COPY packages.sh /
 RUN ["sh", "packages.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN tar -xf arachni-2.0dev-1.0dev-linux-x86_64.tar.gz && mv arachni-2.0dev-1.0de
 ENV PYCURL_SSL_LIBRARY openssl
 
 #download latest OWTF
-RUN git clone -b master https://github.com/r3naissance/owtf.git
+RUN git clone -b master https://github.com/owtf/owtf.git
 RUN mkdir -p /owtf/data/tools/restricted
 
 ENV TERM xterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN ["sh", "packages.sh"]
 RUN apt-get clean
 RUN apt-get -y autoremove
 
-RUN apt-get install kali-linux-top10 kali-linux-web
+# Install some Kali components
+# See https://www.kali.org/news/kali-linux-metapackages/ for details
+RUN apt-get install -y kali-linux-top10 kali-linux-web
 
 #Kali SSL lib-fix
 ENV PYCURL_SSL_LIBRARY openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,7 @@ RUN ["sh", "packages.sh"]
 RUN apt-get clean
 RUN apt-get -y autoremove
 
-# dowload optional packages archives
-COPY optional_tools.sh /usr/bin/
-RUN chmod +x /usr/bin/optional_tools.sh
-
-RUN /bin/bash /usr/bin/optional_tools.sh
+RUN apt-get install kali-linux-full
 
 #Kali SSL lib-fix
 ENV PYCURL_SSL_LIBRARY openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,23 @@ RUN ["sh", "packages.sh"]
 RUN apt-get clean
 RUN apt-get -y autoremove
 
-# Install some Kali components
-# See https://www.kali.org/news/kali-linux-metapackages/ for details
-RUN apt-get install -y kali-linux-top10 kali-linux-web
+RUN apt-get install -y kali-linux-web
+
+# Fixing Wapiti
+RUN apt-get remove -y wapiti
+RUN wget https://phoenixnap.dl.sourceforge.net/project/wapiti/wapiti/wapiti-3.0.1/wapiti3-3.0.1.tar.gz && tar -xf wapiti3-3.0.1.tar.gz
+RUN cd wapiti3-3.0.1 && python3 setup.py install
+RUN wget -P /root/config http://cirt.net/nikto/UPDATES/2.1.5/db_tests && mv /root/config/db_tests /root/config/nikto_db
+
+# Fixing Arachni
+RUN rm -rf /usr/share/arachni && wget http://downloads.arachni-scanner.com/nightlies/arachni-2.0dev-1.0dev-linux-x86_64.tar.gz
+RUN tar -xf arachni-2.0dev-1.0dev-linux-x86_64.tar.gz && mv arachni-2.0dev-1.0dev /usr/share/arachni
 
 #Kali SSL lib-fix
 ENV PYCURL_SSL_LIBRARY openssl
 
 #download latest OWTF
-RUN git clone -b master https://github.com/owtf/owtf.git
+RUN git clone -b master https://github.com/r3naissance/owtf.git
 RUN mkdir -p /owtf/data/tools/restricted
 
 ENV TERM xterm

--- a/optional_tools.sh
+++ b/optional_tools.sh
@@ -11,6 +11,7 @@ PACKAGES="theharvester \
           wapiti \
           hydra \
           metagoofil \
+          arachni \
           o-saft"
 
 if [ "$1" = "--download-only" ]; then


### PR DESCRIPTION
Instead of using a file to install kali dependencies, I found it was simpler to just install the kali-linux-web package. It will include everything that's needed and more. Just in case...

You'll notice as well that Wapiti and Arachni are actually being taken from source, installed, and added to the appropriate folders.