### PR TITLE
Kali image and installing wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali-rolling
 
 MAINTAINER @viyatb viyat.bhalodia@owasp.org, @alexandrasandulescu alecsandra.sandulescu@gmail.com
 
 # Kali signatures preventive update
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y gnupg
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y gnupg && apt-get install wget -y
 RUN wget -q -O - archive.kali.org/archive-key.asc | apt-key add
 
 # install required packages from Kali repos


### PR DESCRIPTION
Downloading the latest official Kali Linux image for docker.
Manually installing wget since it doesn't come preinstalled with the kali docker image.