### PR TITLE
Default to OWTF develop branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali-rolling
 
 MAINTAINER @viyatb viyat.bhalodia@owasp.org, @alexandrasandulescu alecsandra.sandulescu@gmail.com
 
@@ -24,7 +24,10 @@ RUN /bin/bash /usr/bin/optional_tools.sh
 ENV PYCURL_SSL_LIBRARY openssl
 
 #download latest OWTF
-RUN git clone -b master https://github.com/owtf/owtf.git
+ARG OWTF_VERSION=develop
+RUN git clone https://github.com/owtf/owtf.git \
+    && cd owtf \
+    && git checkout ${OWTF_VERSION}
 RUN mkdir -p /owtf/data/tools/restricted
 
 ENV TERM xterm
@@ -33,7 +36,8 @@ ENV SHELL /bin/bash
 WORKDIR /owtf
 
 # core installation
-RUN python setup.py develop
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && python3 -m pip install --no-cache-dir -e .
 
 # expose ports
 EXPOSE 8010 8009 8008

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Official Docker image for [OWASP OWTF](http://owtf.org).
 
+This image builds the OWTF `develop` branch by default. You can override the
+`OWTF_VERSION` build argument to pin the image to a different tag or branch if
+needed.
+
 ### Building the image:
 
 *  Install **Docker**.(specific instructions can be found [here](https://docs.docker.com/installation/)).

--- a/owtf_entry.sh
+++ b/owtf_entry.sh
@@ -36,4 +36,4 @@ if [ $# -gt 0 ]; then
 fi
 
 # Run owtf
-python -m owtf
+python3 -m owtf

--- a/packages.sh
+++ b/packages.sh
@@ -1,7 +1,11 @@
 apt-get install -y  sudo \
                     git \
-                    python-setuptools \
-                    python-pip \
+                    python3 \
+                    python3-setuptools \
+                    python3-pip \
+                    python3-dev \
+                    python3-venv \
+                    python3-wheel \
                     xvfb \
                     xserver-xephyr \
                     libxml2-dev \
@@ -14,7 +18,6 @@ apt-get install -y  sudo \
                     libssl-dev \
                     libz-dev \
                     libffi-dev \
-                    python-dev \
                     postgresql \
                     postgresql-client \
                     postgresql-client-common \


### PR DESCRIPTION
## Summary
- set the default OWTF checkout to the develop branch in the Docker build
- document that the image builds from the develop branch by default

## Testing